### PR TITLE
Upgrade to .NET 10 and update NuGet packages

### DIFF
--- a/Likvido.Kubesec/Likvido.Kubesec/Likvido.Kubesec.csproj
+++ b/Likvido.Kubesec/Likvido.Kubesec/Likvido.Kubesec.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>kubesec</ToolCommandName>
         <PackageOutputPath>./nupkg</PackageOutputPath>
@@ -16,10 +16,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Spectre.Console" Version="0.48.0" />
-        <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
-        <PackageReference Include="YamlDotNet" Version="15.1.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+        <PackageReference Include="Spectre.Console" Version="0.54.0" />
+        <PackageReference Include="System.CommandLine" Version="2.0.2" />
+        <PackageReference Include="YamlDotNet" Version="16.3.0" />
     </ItemGroup>
 
 </Project>

--- a/Likvido.Kubesec/Likvido.Kubesec/Program.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/Program.cs
@@ -44,13 +44,13 @@ static Command CreatePullCommand()
         if (configurePortForwarding && string.IsNullOrWhiteSpace(unwrapKeyName))
         {
             Console.WriteLine("When using the port-forward flag, you also have to specify the unwrap-key option");
-            return await Task.FromResult(0);
+            return 1;
         }
 
         if (jsonFieldsToDelete != null && string.IsNullOrWhiteSpace(unwrapKeyName))
         {
             Console.WriteLine("When using the remove-json-fields option, you also have to specify the unwrap-key option");
-            return await Task.FromResult(0);
+            return 1;
         }
 
         return await TryCommandAsync(() => PullCommand.Run(secret, configurePortForwarding, output, context, @namespace, unwrapKeyName, jsonFieldsToDelete));

--- a/Likvido.Kubesec/Likvido.Kubesec/Program.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/Program.cs
@@ -9,7 +9,7 @@ var rootCommand = new RootCommand("Kubernetes secret configuration helper")
     CreateRestoreCommand()
 };
 
-return rootCommand.Parse(args).Invoke();
+return await rootCommand.Parse(args).InvokeAsync();
 
 static Command CreatePullCommand()
 {

--- a/Likvido.Kubesec/Likvido.Kubesec/Program.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/Program.cs
@@ -9,18 +9,17 @@ var rootCommand = new RootCommand("Kubernetes secret configuration helper")
     CreateRestoreCommand()
 };
 
-return await rootCommand.InvokeAsync(args);
+return rootCommand.Parse(args).Invoke();
 
 static Command CreatePullCommand()
 {
-    var argumentSecret = new Argument<string>("secret", "The name of the secret in kubernetes");
-    var optionContext = new Option<string>(new[] { "--context", "-c" }, "The kubectl config context to use");
-    var optionNamespace =
-        new Option<string>(new[] { "--namespace", "-n" }, "The namespace of services in kubernetes");
-    var optionOutput = new Option<string>(new[] { "--output", "-o" }, "The file to write to");
-    var optionUnwrapKey = new Option<string>(new[] { "--unwrap-key", "-u" }, "Unwrap a specific key (so we only output the value of this key)");
-    var optionPortForward = new Option<bool>(new[] { "--port-forward", "-p" }, "Will run port-forwards and replace any Kubernetes service URLs in the config (requires the unwrap-key option as well)");
-    var optionRemoveJsonFields = new Option<List<string>>(new[] { "--remove-json-field", "-r" }, "Will delete the listed fields from the unwrapped json secret value (requires the unwrap-key option as well)");
+    var argumentSecret = new Argument<string>("secret") { Description = "The name of the secret in kubernetes" };
+    var optionContext = new Option<string>("--context", "-c") { Description = "The kubectl config context to use" };
+    var optionNamespace = new Option<string>("--namespace", "-n") { Description = "The namespace of services in kubernetes" };
+    var optionOutput = new Option<string>("--output", "-o") { Description = "The file to write to" };
+    var optionUnwrapKey = new Option<string>("--unwrap-key", "-u") { Description = "Unwrap a specific key (so we only output the value of this key)" };
+    var optionPortForward = new Option<bool>("--port-forward", "-p") { Description = "Will run port-forwards and replace any Kubernetes service URLs in the config (requires the unwrap-key option as well)" };
+    var optionRemoveJsonFields = new Option<List<string>>("--remove-json-field", "-r") { Description = "Will delete the listed fields from the unwrapped json secret value (requires the unwrap-key option as well)" };
     var cmd = new Command("pull", "Pulls secrets from kubernetes to a local file")
     {
         argumentSecret,
@@ -32,36 +31,42 @@ static Command CreatePullCommand()
         optionRemoveJsonFields
     };
 
-    cmd.SetHandler(
-        (string secret, string? output, string? context, string? @namespace, string? unwrapKeyName, bool configurePortForwarding, List<string>? jsonFieldsToDelete) =>
+    cmd.SetAction(async (parseResult, cancellationToken) =>
+    {
+        var secret = parseResult.GetValue(argumentSecret)!;
+        var output = parseResult.GetValue(optionOutput);
+        var context = parseResult.GetValue(optionContext);
+        var @namespace = parseResult.GetValue(optionNamespace);
+        var unwrapKeyName = parseResult.GetValue(optionUnwrapKey);
+        var configurePortForwarding = parseResult.GetValue(optionPortForward);
+        var jsonFieldsToDelete = parseResult.GetValue(optionRemoveJsonFields);
+
+        if (configurePortForwarding && string.IsNullOrWhiteSpace(unwrapKeyName))
         {
-            if (configurePortForwarding && string.IsNullOrWhiteSpace(unwrapKeyName))
-            {
-                Console.WriteLine("When using the port-forward flag, you also have to specify the unwrap-key option");
-                return Task.FromResult(0);
-            }
+            Console.WriteLine("When using the port-forward flag, you also have to specify the unwrap-key option");
+            return await Task.FromResult(0);
+        }
 
-            if (jsonFieldsToDelete != null && string.IsNullOrWhiteSpace(unwrapKeyName))
-            {
-                Console.WriteLine("When using the remove-json-fields option, you also have to specify the unwrap-key option");
-                return Task.FromResult(0);
-            }
+        if (jsonFieldsToDelete != null && string.IsNullOrWhiteSpace(unwrapKeyName))
+        {
+            Console.WriteLine("When using the remove-json-fields option, you also have to specify the unwrap-key option");
+            return await Task.FromResult(0);
+        }
 
-            return TryCommandAsync(() => PullCommand.Run(secret, configurePortForwarding, output, context, @namespace, unwrapKeyName, jsonFieldsToDelete));
-        },
-        argumentSecret, optionOutput, optionContext, optionNamespace, optionUnwrapKey, optionPortForward, optionRemoveJsonFields);
+        return await TryCommandAsync(() => PullCommand.Run(secret, configurePortForwarding, output, context, @namespace, unwrapKeyName, jsonFieldsToDelete));
+    });
 
     return cmd;
 }
 
 static Command CreatePushCommand()
 {
-    var argumentFile = new Argument<string>("file", "The file to read from");
-    var optionContext = new Option<string>(new[] { "--context", "-c" }, "The kubectl config context to use");
-    var optionSecret = new Option<string>(new[] { "--secret", "-s" }, "The name of the secret in kubernetes");
-    var optionNamespace = new Option<string>(new[] { "--namespace", "-n" }, "The namespace of services in kubernetes");
-    var optionSkipPrompts = new Option<bool>(new[] { "--skip-prompts", "-sp" }, "Will not ask for confirmation before pushing secret");
-    var optionAutoCreateMissingNamespace = new Option<bool>(new[] { "--auto-create-missing-namespace", "-acmn" }, "Will automatically create the namespace if it does not exist");
+    var argumentFile = new Argument<string>("file") { Description = "The file to read from" };
+    var optionContext = new Option<string>("--context", "-c") { Description = "The kubectl config context to use" };
+    var optionSecret = new Option<string>("--secret", "-s") { Description = "The name of the secret in kubernetes" };
+    var optionNamespace = new Option<string>("--namespace", "-n") { Description = "The namespace of services in kubernetes" };
+    var optionSkipPrompts = new Option<bool>("--skip-prompts", "-sp") { Description = "Will not ask for confirmation before pushing secret" };
+    var optionAutoCreateMissingNamespace = new Option<bool>("--auto-create-missing-namespace", "-acmn") { Description = "Will automatically create the namespace if it does not exist" };
     var cmd = new Command("push", "Pushes secrets from a local file into kubernetes")
     {
         argumentFile,
@@ -72,27 +77,28 @@ static Command CreatePushCommand()
         optionAutoCreateMissingNamespace
     };
 
-    cmd.SetHandler(
-        (string file, string? context, string? secret, string? @namespace, bool skipPrompts, bool autoCreateMissingNamespace) =>
-        {
-            return Task.FromResult(TryCommand(() => PushCommand.Run(file, context, secret, @namespace, skipPrompts, autoCreateMissingNamespace)));
-        },
-        argumentFile, optionContext, optionSecret, optionNamespace, optionSkipPrompts, optionAutoCreateMissingNamespace);
+    cmd.SetAction(async (parseResult, cancellationToken) =>
+    {
+        var file = parseResult.GetValue(argumentFile)!;
+        var context = parseResult.GetValue(optionContext);
+        var secret = parseResult.GetValue(optionSecret);
+        var @namespace = parseResult.GetValue(optionNamespace);
+        var skipPrompts = parseResult.GetValue(optionSkipPrompts);
+        var autoCreateMissingNamespace = parseResult.GetValue(optionAutoCreateMissingNamespace);
+
+        return await Task.FromResult(TryCommand(() => PushCommand.Run(file, context, secret, @namespace, skipPrompts, autoCreateMissingNamespace)));
+    });
 
     return cmd;
 }
 
 static Command CreateBackupCommand()
 {
-    var optionContext = new Option<string>(new[] { "--context", "-c" }, "The kubectl config context to use");
-    var optionNamespace =
-        new Option<string>(new[] { "--namespace", "-n" }, "The namespace of services in kubernetes");
-    var optionNamespaceIncludes = new Option<string>(new[] { "--namespace-includes", "-i" },
-        "The namespace keyword of services in kubernetes");
-    var optionNamespaceRegex = new Option<string>(new[] { "--namespace-regex", "-rgx" },
-        "The namespace regex to search for services in kubernetes");
-    var optionExcludedNamespaces = new Option<string[]>(new[] { "--excluded-namespace", "-e" },
-        "A list of namespaces that should not be included in the backup");
+    var optionContext = new Option<string>("--context", "-c") { Description = "The kubectl config context to use" };
+    var optionNamespace = new Option<string>("--namespace", "-n") { Description = "The namespace of services in kubernetes" };
+    var optionNamespaceIncludes = new Option<string>("--namespace-includes", "-i") { Description = "The namespace keyword of services in kubernetes" };
+    var optionNamespaceRegex = new Option<string>("--namespace-regex", "-rgx") { Description = "The namespace regex to search for services in kubernetes" };
+    var optionExcludedNamespaces = new Option<string[]>("--excluded-namespace", "-e") { Description = "A list of namespaces that should not be included in the backup" };
     var cmd = new Command("backup", "Pulls all secrets in the cluster")
     {
         optionContext,
@@ -102,24 +108,27 @@ static Command CreateBackupCommand()
         optionExcludedNamespaces
     };
 
-    cmd.SetHandler(
-        (string? context, string? @namespace, string? namespaceIncludes, string? namespaceRegex, string[]? excludedNamespaces) =>
-        {
-            return Task.FromResult(TryCommand(() =>
-                BackupCommand.Run(context, @namespace, namespaceIncludes, namespaceRegex, excludedNamespaces)));
-        },
-        optionContext, optionNamespace, optionNamespaceIncludes, optionNamespaceRegex, optionExcludedNamespaces);
+    cmd.SetAction(async (parseResult, cancellationToken) =>
+    {
+        var context = parseResult.GetValue(optionContext);
+        var @namespace = parseResult.GetValue(optionNamespace);
+        var namespaceIncludes = parseResult.GetValue(optionNamespaceIncludes);
+        var namespaceRegex = parseResult.GetValue(optionNamespaceRegex);
+        var excludedNamespaces = parseResult.GetValue(optionExcludedNamespaces);
+
+        return await Task.FromResult(TryCommand(() => BackupCommand.Run(context, @namespace, namespaceIncludes, namespaceRegex, excludedNamespaces)));
+    });
 
     return cmd;
 }
 
 static Command CreateRestoreCommand()
 {
-    var argumentFolder = new Argument<string>("folder", "The folder containing all the secret files to push");
-    var optionContext = new Option<string>(new[] { "--context", "-c" }, "The kubectl config context to use");
-    var optionRecursive = new Option<bool>(new[] { "--recursive", "-r" }, "Will recursively push secrets");
-    var optionSkipPrompts = new Option<bool>(new[] { "--skip-prompts", "-sp" }, "Will not ask for confirmation before pushing secrets");
-    var optionAutoCreateMissingNamespaces = new Option<bool>(new[] { "--auto-create-missing-namespaces", "-acmn" }, "Will automatically create missing namespaces when pushing secrets");
+    var argumentFolder = new Argument<string>("folder") { Description = "The folder containing all the secret files to push" };
+    var optionContext = new Option<string>("--context", "-c") { Description = "The kubectl config context to use" };
+    var optionRecursive = new Option<bool>("--recursive", "-r") { Description = "Will recursively push secrets" };
+    var optionSkipPrompts = new Option<bool>("--skip-prompts", "-sp") { Description = "Will not ask for confirmation before pushing secrets" };
+    var optionAutoCreateMissingNamespaces = new Option<bool>("--auto-create-missing-namespaces", "-acmn") { Description = "Will automatically create missing namespaces when pushing secrets" };
     var cmd = new Command("restore", "Pushes all secrets in a given folder")
     {
         argumentFolder,
@@ -129,12 +138,16 @@ static Command CreateRestoreCommand()
         optionAutoCreateMissingNamespaces
     };
 
-    cmd.SetHandler(
-        (string folder, string? context, bool recursive, bool skipPrompts, bool autoCreateMissingNamespaces) =>
-        {
-            return Task.FromResult(TryCommand(() => RestoreCommand.Run(folder, context, recursive, skipPrompts, autoCreateMissingNamespaces)));
-        },
-        argumentFolder, optionContext, optionRecursive, optionSkipPrompts, optionAutoCreateMissingNamespaces);
+    cmd.SetAction(async (parseResult, cancellationToken) =>
+    {
+        var folder = parseResult.GetValue(argumentFolder)!;
+        var context = parseResult.GetValue(optionContext);
+        var recursive = parseResult.GetValue(optionRecursive);
+        var skipPrompts = parseResult.GetValue(optionSkipPrompts);
+        var autoCreateMissingNamespaces = parseResult.GetValue(optionAutoCreateMissingNamespaces);
+
+        return await Task.FromResult(TryCommand(() => RestoreCommand.Run(folder, context, recursive, skipPrompts, autoCreateMissingNamespaces)));
+    });
 
     return cmd;
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 Tool to ease the management of Kubernetes secrets
 
 ## Requirements
-[kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) needs to be installed and configured for your cluster.
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) needs to be installed and configured for your cluster
 
 ## Installation
 Install this tool via dotnet global tools:


### PR DESCRIPTION
Upgrades the project to .NET 10 and updates all NuGet packages to their latest versions. The System.CommandLine package was updated from beta to stable 2.0.2, requiring API migration from SetHandler to SetAction. All code changes compiled and verified.

Updated dependencies:
- Newtonsoft.Json: 13.0.3 → 13.0.4
- Spectre.Console: 0.48.0 → 0.54.0
- System.CommandLine: 2.0.0-beta3 → 2.0.2
- YamlDotNet: 15.1.2 → 16.3.0

README updated with .NET 10 SDK requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger command parameter validation to prevent invalid flag combinations (e.g., port-forward and JSON field operations).

* **Refactor**
  * Command handling moved to an asynchronous parse-then-invoke flow for clearer validation and more reliable execution.

* **Chores**
  * Target framework bumped to .NET 10; several libraries updated to newer stable versions.

* **Documentation**
  * Requirements updated to list .NET 10 SDK as a prerequisite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->