### PR TITLE
Likvido/Likvido.App#26094 Add find and update-value commands

### DIFF
--- a/Likvido.Kubesec/Likvido.Kubesec/BackupCommand.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/BackupCommand.cs
@@ -3,28 +3,49 @@
 public static class BackupCommand
 {
     public static int Run(string? context = null, string? @namespace = null, string? namespaceIncludes = null,
-        string? namespaceRegex = null, string[]? excludedNamespaces = null)
+        string? namespaceRegex = null, string[]? excludedNamespaces = null, CancellationToken cancellationToken = default)
     {
         var backupFolder = $"Kubesec_Backup_{context}_{DateTime.Now:yyyyMMddTHHmmss}";
+        var kubeCtl = new KubeCtl(context);
+
+        CreateBackup(kubeCtl, backupFolder, context, @namespace, namespaceIncludes, namespaceRegex, excludedNamespaces, cancellationToken);
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Creates a backup and returns the secrets that were backed up.
+    /// </summary>
+    public static Dictionary<(string Namespace, string Name), IReadOnlyList<Secret>> CreateBackup(
+        KubeCtl kubeCtl,
+        string backupFolder,
+        string? context = null,
+        string? @namespace = null,
+        string? namespaceIncludes = null,
+        string? namespaceRegex = null,
+        string[]? excludedNamespaces = null,
+        CancellationToken cancellationToken = default)
+    {
         Directory.CreateDirectory(backupFolder);
 
-        var kubeCtl = new KubeCtl(context);
-        var allSecrets = kubeCtl.GetNamespacesWithSecrets(@namespace, namespaceIncludes, namespaceRegex, excludedNamespaces);
+        var allSecrets = kubeCtl.GetNamespacesWithSecrets(@namespace, namespaceIncludes, namespaceRegex, excludedNamespaces, cancellationToken);
 
         foreach (var secret in allSecrets)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var namespaceItem = secret.Key.Namespace;
             var secretsName = secret.Key.Name;
             var namespaceSubDirectory = $"{backupFolder}/{namespaceItem}";
-            //create subfolders for namespaces
-            if (!Directory.Exists($"{namespaceSubDirectory}"))
+
+            if (!Directory.Exists(namespaceSubDirectory))
             {
-                Directory.CreateDirectory($"{namespaceSubDirectory}");
+                Directory.CreateDirectory(namespaceSubDirectory);
             }
 
             Utils.WriteToFile($"{namespaceSubDirectory}/{secretsName}.yaml", secret.Value, secretsName, context, namespaceItem);
         }
 
-        return 0;
+        return allSecrets;
     }
 }

--- a/Likvido.Kubesec/Likvido.Kubesec/Exceptions/KubeCtlException.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/Exceptions/KubeCtlException.cs
@@ -1,9 +1,3 @@
 ﻿namespace Likvido.Kubesec.Exceptions;
 
-public class KubeCtlException : Exception
-{
-    public KubeCtlException(string message)
-        : base(message)
-    {
-    }
-}
+public class KubeCtlException(string message) : Exception(message);

--- a/Likvido.Kubesec/Likvido.Kubesec/FindCommand.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/FindCommand.cs
@@ -1,0 +1,195 @@
+using Spectre.Console;
+
+namespace Likvido.Kubesec;
+
+public static class FindCommand
+{
+    public static int Run(
+        string searchTerm,
+        string? context = null,
+        string? @namespace = null,
+        string? namespaceIncludes = null,
+        string? namespaceRegex = null,
+        CancellationToken cancellationToken = default)
+    {
+        var kubeCtl = new KubeCtl(context);
+        var allSecrets = kubeCtl.GetNamespacesWithSecrets(@namespace, namespaceIncludes, namespaceRegex, cancellationToken: cancellationToken);
+
+        var results = SearchSecrets(allSecrets, searchTerm);
+
+        if (results.Count == 0)
+        {
+            AnsiConsole.MarkupLine($"[yellow]No matches found for:[/] {Markup.Escape(searchTerm)}");
+            return 0;
+        }
+
+        DisplayResults(searchTerm, results);
+        return 0;
+    }
+
+    private static List<SearchResult> SearchSecrets(
+        Dictionary<(string Namespace, string Name), IReadOnlyList<Secret>> allSecrets,
+        string searchTerm)
+    {
+        var results = new List<SearchResult>();
+
+        foreach (var secretEntry in allSecrets)
+        {
+            var (@namespace, secretName) = secretEntry.Key;
+
+            foreach (var secret in secretEntry.Value)
+            {
+                var matches = FindMatchesWithContext(secret.Value, searchTerm, contextLines: 2);
+
+                if (matches.Count > 0)
+                {
+                    results.Add(new SearchResult(
+                        @namespace,
+                        secretName,
+                        secret.Name,
+                        matches));
+                }
+            }
+        }
+
+        return results;
+    }
+
+    private static List<MatchContext> FindMatchesWithContext(
+        string content,
+        string searchTerm,
+        int contextLines)
+    {
+        var matches = new List<MatchContext>();
+        var lines = content.Split('\n');
+        var matchedLineIndices = new HashSet<int>();
+
+        // First pass: find all lines that contain the search term
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+            {
+                matchedLineIndices.Add(i);
+            }
+        }
+
+        // Second pass: create context blocks, merging overlapping ranges
+        var processedLines = new HashSet<int>();
+
+        foreach (var matchIndex in matchedLineIndices.OrderBy(x => x))
+        {
+            if (processedLines.Contains(matchIndex))
+            {
+                continue;
+            }
+
+            var startLine = Math.Max(0, matchIndex - contextLines);
+            var endLine = Math.Min(lines.Length - 1, matchIndex + contextLines);
+
+            // Extend range to include any other matches that fall within or adjacent
+            var extendedEnd = endLine;
+            foreach (var otherMatch in matchedLineIndices.Where(m => m > matchIndex && m <= endLine + contextLines))
+            {
+                extendedEnd = Math.Min(lines.Length - 1, otherMatch + contextLines);
+                processedLines.Add(otherMatch);
+            }
+
+            endLine = extendedEnd;
+
+            var contextText = string.Join('\n',
+                lines.Skip(startLine).Take(endLine - startLine + 1));
+
+            // Find which lines within this context block are matches
+            var matchLinesInContext = matchedLineIndices
+                .Where(m => m >= startLine && m <= endLine)
+                .Select(m => m - startLine)
+                .ToList();
+
+            matches.Add(new MatchContext(
+                LineNumber: matchIndex + 1, // 1-based line numbers
+                ContextText: contextText,
+                MatchLineIndices: matchLinesInContext));
+
+            processedLines.Add(matchIndex);
+        }
+
+        return matches;
+    }
+
+    private static void DisplayResults(string searchTerm, List<SearchResult> results)
+    {
+        AnsiConsole.MarkupLine($"[bold]Finding:[/] {Markup.Escape(searchTerm)}");
+        AnsiConsole.WriteLine(new string('=', 45));
+        AnsiConsole.WriteLine();
+
+        foreach (var result in results)
+        {
+            AnsiConsole.MarkupLine($"[green]>[/] [bold]{Markup.Escape(result.Namespace)}/{Markup.Escape(result.SecretName)}[/]");
+
+            foreach (var match in result.Matches)
+            {
+                AnsiConsole.MarkupLine($"  [dim]Key:[/] {Markup.Escape(result.KeyName)}");
+                AnsiConsole.MarkupLine($"  [dim]Line {match.LineNumber}:[/]");
+
+                // Display context with highlighting
+                var contextLines = match.ContextText.Split('\n');
+                for (int i = 0; i < contextLines.Length; i++)
+                {
+                    var isMatchLine = match.MatchLineIndices.Contains(i);
+                    var prefix = isMatchLine ? "[yellow]>[/]" : " ";
+                    var line = Markup.Escape(contextLines[i]);
+
+                    // Highlight the search term in matching lines
+                    if (isMatchLine)
+                    {
+                        line = HighlightSearchTerm(contextLines[i], searchTerm);
+                    }
+
+                    AnsiConsole.MarkupLine($"    {prefix} {line}");
+                }
+
+                AnsiConsole.WriteLine();
+            }
+        }
+
+        AnsiConsole.MarkupLine($"[bold]Found {results.Count} secret(s) containing the search term[/]");
+    }
+
+    private static string HighlightSearchTerm(string line, string searchTerm)
+    {
+        // Find all occurrences and highlight them
+        var escapedLine = Markup.Escape(line);
+        var escapedTerm = Markup.Escape(searchTerm);
+
+        // Case-insensitive replacement for highlighting
+        var index = 0;
+        var result = escapedLine;
+
+        while (true)
+        {
+            var foundIndex = result.IndexOf(escapedTerm, index, StringComparison.OrdinalIgnoreCase);
+            if (foundIndex < 0)
+            {
+                break;
+            }
+
+            var actualMatch = result.Substring(foundIndex, escapedTerm.Length);
+            var highlighted = $"[bold yellow]{actualMatch}[/]";
+            result = result[..foundIndex] + highlighted + result[(foundIndex + escapedTerm.Length)..];
+            index = foundIndex + highlighted.Length;
+        }
+
+        return result;
+    }
+
+    private record SearchResult(
+        string Namespace,
+        string SecretName,
+        string KeyName,
+        List<MatchContext> Matches);
+
+    private record MatchContext(
+        int LineNumber,
+        string ContextText,
+        List<int> MatchLineIndices);
+}

--- a/Likvido.Kubesec/Likvido.Kubesec/PullCommand.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/PullCommand.cs
@@ -13,7 +13,8 @@ public static class PullCommand
         string? context = null,
         string? @namespace = null,
         string? unwrapKeyName = null,
-        List<string>? jsonFieldsToDelete = null)
+        List<string>? jsonFieldsToDelete = null,
+        CancellationToken cancellationToken = default)
     {
         var portForwardingStarted = false;
         var kubeCtl = new KubeCtl(context);
@@ -81,9 +82,9 @@ public static class PullCommand
             try
             {
                 Console.WriteLine("Port forwarding configured. To stop the port forwarding, kill kubesec");
-                await Task.Delay(Timeout.Infinite).ConfigureAwait(false);
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
             }
-            catch(TaskCanceledException) { /* Ignored */ }
+            catch (TaskCanceledException) { /* Ignored */ }
         }
 
         return 0;

--- a/Likvido.Kubesec/Likvido.Kubesec/PushCommand.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/PushCommand.cs
@@ -103,7 +103,7 @@ public static class PushCommand
         return 0;
     }
 
-    private static string CreateSecretsTempFile(string secretName, string @namespace, IReadOnlyList<Secret> secrets)
+    public static string CreateSecretsTempFile(string secretName, string @namespace, IReadOnlyList<Secret> secrets)
     {
         var contentBuilder = new StringBuilder();
 

--- a/Likvido.Kubesec/Likvido.Kubesec/RestoreCommand.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/RestoreCommand.cs
@@ -2,31 +2,35 @@
 
 public static class RestoreCommand
 {
-    public static int Run(string folder, string? context, bool recursive, bool skipPrompts = false, bool autoCreateMissingNamespaces = false)
+    public static int Run(string folder, string? context, bool recursive, bool skipPrompts = false, bool autoCreateMissingNamespaces = false, CancellationToken cancellationToken = default)
     {
-        RestoreFiles(folder, context, skipPrompts, autoCreateMissingNamespaces);
+        RestoreFiles(folder, context, skipPrompts, autoCreateMissingNamespaces, cancellationToken);
 
         if (recursive)
         {
-            RecursiveRestore(folder, context, skipPrompts, autoCreateMissingNamespaces);
+            RecursiveRestore(folder, context, skipPrompts, autoCreateMissingNamespaces, cancellationToken);
         }
 
         return 0;
     }
 
-    private static void RecursiveRestore(string folder, string? context, bool skipPrompts, bool autoCreateMissingNamespaces)
+    private static void RecursiveRestore(string folder, string? context, bool skipPrompts, bool autoCreateMissingNamespaces, CancellationToken cancellationToken)
     {
         foreach (var directory in Directory.EnumerateDirectories(folder))
         {
-            RestoreFiles(directory, context, skipPrompts, autoCreateMissingNamespaces);
-            RecursiveRestore(directory, context, skipPrompts, autoCreateMissingNamespaces);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            RestoreFiles(directory, context, skipPrompts, autoCreateMissingNamespaces, cancellationToken);
+            RecursiveRestore(directory, context, skipPrompts, autoCreateMissingNamespaces, cancellationToken);
         }
     }
 
-    private static void RestoreFiles(string folder, string? context, bool skipPrompts, bool autoCreateMissingNamespaces)
+    private static void RestoreFiles(string folder, string? context, bool skipPrompts, bool autoCreateMissingNamespaces, CancellationToken cancellationToken)
     {
         foreach (var file in Directory.EnumerateFiles(folder))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Skip .DS_Store files
             if (Path.GetFileName(file) == ".DS_Store")
             {

--- a/Likvido.Kubesec/Likvido.Kubesec/Secret.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/Secret.cs
@@ -1,14 +1,8 @@
 ﻿namespace Likvido.Kubesec;
 
-public class Secret
+public class Secret(string name, string value)
 {
-    public Secret(string name, string value)
-    {
-        Name = name;
-        Value = value;
-    }
+    public string Name { get; } = name;
 
-    public string Name { get; }
-
-    public string Value { get; set; }
+    public string Value { get; set; } = value;
 }

--- a/Likvido.Kubesec/Likvido.Kubesec/UpdateValueCommand.cs
+++ b/Likvido.Kubesec/Likvido.Kubesec/UpdateValueCommand.cs
@@ -1,0 +1,295 @@
+using Spectre.Console;
+
+namespace Likvido.Kubesec;
+
+public static class UpdateValueCommand
+{
+    public static int Run(
+        string oldValue,
+        string newValue,
+        string? context = null,
+        string? @namespace = null,
+        string? namespaceIncludes = null,
+        string? namespaceRegex = null,
+        bool skipPrompts = false,
+        bool dryRun = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (oldValue == newValue)
+        {
+            AnsiConsole.MarkupLine("[red]Error: Old and new values are identical[/]");
+            return 1;
+        }
+
+        // Step 1: Create backup folder
+        var backupFolder = $"kubesec-rollback-{DateTime.Now:yyyyMMdd-HHmmss}";
+
+        AnsiConsole.WriteLine(new string('=', 45));
+        AnsiConsole.MarkupLine("[bold]Replace Values[/]");
+        AnsiConsole.WriteLine(new string('=', 45));
+        AnsiConsole.WriteLine();
+
+        AnsiConsole.MarkupLine($"Old value: [yellow]{Markup.Escape(TruncateForDisplay(oldValue, 60))}[/]");
+        AnsiConsole.MarkupLine($"New value: [yellow]{Markup.Escape(TruncateForDisplay(newValue, 60))}[/]");
+        AnsiConsole.WriteLine();
+
+        var kubeCtl = new KubeCtl(context);
+        Dictionary<(string Namespace, string Name), IReadOnlyList<Secret>> allSecrets;
+
+        if (dryRun)
+        {
+            AnsiConsole.MarkupLine("[dim]Dry run mode - no changes will be made[/]");
+            AnsiConsole.WriteLine();
+            allSecrets = kubeCtl.GetNamespacesWithSecrets(@namespace, namespaceIncludes, namespaceRegex, cancellationToken: cancellationToken);
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"Creating backup to [cyan]{backupFolder}/[/]");
+            AnsiConsole.WriteLine();
+            allSecrets = BackupCommand.CreateBackup(kubeCtl, backupFolder, context, @namespace, namespaceIncludes, namespaceRegex, cancellationToken: cancellationToken);
+        }
+
+        // Step 2: Find matches in the backed up secrets
+        var matchingSecrets = new List<SecretUpdateInfo>();
+
+        AnsiConsole.MarkupLine("Finding secrets containing the old value...");
+        AnsiConsole.WriteLine();
+
+        foreach (var secretEntry in allSecrets)
+        {
+            var (ns, secretName) = secretEntry.Key;
+            var secrets = secretEntry.Value;
+
+            // Check for matches in each secret key
+            foreach (var secret in secrets)
+            {
+                if (secret.Value.Contains(oldValue, StringComparison.Ordinal))
+                {
+                    var occurrenceCount = CountOccurrences(secret.Value, oldValue);
+                    matchingSecrets.Add(new SecretUpdateInfo(
+                        ns,
+                        secretName,
+                        secret.Name,
+                        secret.Value,
+                        secret.Value.Replace(oldValue, newValue),
+                        occurrenceCount,
+                        secrets.ToList()));
+                }
+            }
+        }
+
+        if (matchingSecrets.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No secrets found containing the specified value.[/]");
+
+            // Clean up empty backup folder
+            if (!dryRun && Directory.Exists(backupFolder))
+            {
+                Directory.Delete(backupFolder, true);
+                AnsiConsole.MarkupLine("[dim]Removed empty backup folder.[/]");
+            }
+
+            return 0;
+        }
+
+        // Group by namespace/secret for counting unique secrets
+        var uniqueSecrets = matchingSecrets
+            .GroupBy(m => (m.Namespace, m.SecretName))
+            .ToList();
+
+        AnsiConsole.MarkupLine($"Found [green]{uniqueSecrets.Count}[/] secret(s) containing the value");
+        AnsiConsole.WriteLine();
+
+        // Step 3: Display preview with diff-style output
+        foreach (var match in matchingSecrets)
+        {
+            DisplayDiff(match, oldValue, newValue);
+        }
+
+        AnsiConsole.WriteLine(new string('=', 45));
+        AnsiConsole.MarkupLine($"[bold]Total: {uniqueSecrets.Count} secret(s) will be updated[/]");
+        AnsiConsole.WriteLine(new string('=', 45));
+        AnsiConsole.WriteLine();
+
+        // Step 4: Handle dry run or confirm with user
+        if (dryRun)
+        {
+            AnsiConsole.MarkupLine("[yellow]Dry run complete - no changes were made.[/]");
+
+            if (!string.IsNullOrEmpty(backupFolder) && Directory.Exists(backupFolder))
+            {
+                Directory.Delete(backupFolder, true);
+            }
+
+            return 0;
+        }
+
+        if (!skipPrompts)
+        {
+            if (!PromptContinue("Apply changes?"))
+            {
+                AnsiConsole.MarkupLine("[yellow]Operation cancelled.[/]");
+                AnsiConsole.MarkupLine($"[dim]Backup preserved at:[/] {backupFolder}/");
+                return 0;
+            }
+        }
+
+        // Step 5: Apply changes
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("Updating secrets...");
+
+        var successCount = 0;
+        var failedSecrets = new List<string>();
+
+        foreach (var group in uniqueSecrets)
+        {
+            var (ns, secretName) = group.Key;
+            var firstMatch = group.First();
+
+            // Create updated secrets list
+            var updatedSecrets = firstMatch.AllSecrets.Select(s =>
+            {
+                var matchForKey = group.FirstOrDefault(m => m.KeyName == s.Name);
+                if (matchForKey != null)
+                {
+                    return new Secret(s.Name, matchForKey.NewValue);
+                }
+
+                return s;
+            }).ToList();
+
+            try
+            {
+                ApplySecretUpdate(kubeCtl, secretName, ns, updatedSecrets);
+                AnsiConsole.MarkupLine($"  [green]OK[/] {Markup.Escape(ns)}/{Markup.Escape(secretName)}");
+                successCount++;
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"  [red]FAILED[/] {Markup.Escape(ns)}/{Markup.Escape(secretName)}: {Markup.Escape(ex.Message)}");
+                failedSecrets.Add($"{ns}/{secretName}");
+            }
+        }
+
+        // Step 6: Report results
+        AnsiConsole.WriteLine();
+        AnsiConsole.WriteLine(new string('=', 45));
+        AnsiConsole.MarkupLine($"[bold]Done! Updated {successCount} secret(s).[/]");
+        AnsiConsole.WriteLine(new string('=', 45));
+
+        if (failedSecrets.Count > 0)
+        {
+            AnsiConsole.MarkupLine($"[red]Failed: {failedSecrets.Count} secret(s)[/]");
+            foreach (var failed in failedSecrets)
+            {
+                AnsiConsole.MarkupLine($"  - {Markup.Escape(failed)}");
+            }
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[bold]Rollback:[/] kubesec restore -c {context ?? "<context>"} {backupFolder}/");
+
+        return failedSecrets.Count > 0 ? 1 : 0;
+    }
+
+    private static void DisplayDiff(SecretUpdateInfo match, string oldValue, string newValue)
+    {
+        AnsiConsole.MarkupLine($"[green]>[/] [bold]{Markup.Escape(match.Namespace)}/{Markup.Escape(match.SecretName)}[/]");
+        AnsiConsole.MarkupLine($"  {match.OccurrenceCount} occurrence(s) will be replaced");
+
+        // Find the line containing the match and show context
+        var lines = match.OldValue.Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Contains(oldValue, StringComparison.Ordinal))
+            {
+                var oldLine = TruncateForDisplay(lines[i].Trim(), 80);
+                var newLine = TruncateForDisplay(lines[i].Replace(oldValue, newValue).Trim(), 80);
+
+                AnsiConsole.MarkupLine($"  [dim]Line {i + 1}:[/]");
+                AnsiConsole.MarkupLine($"    [red]- {Markup.Escape(oldLine)}[/]");
+                AnsiConsole.MarkupLine($"    [green]+ {Markup.Escape(newLine)}[/]");
+
+                // Only show first few matches per secret to avoid overwhelming output
+                if (i > 5)
+                {
+                    AnsiConsole.MarkupLine($"    [dim]... and more[/]");
+                    break;
+                }
+            }
+        }
+
+        AnsiConsole.WriteLine();
+    }
+
+    private static string TruncateForDisplay(string value, int maxLength)
+    {
+        if (value.Length <= maxLength)
+        {
+            return value;
+        }
+
+        var halfLength = (maxLength - 3) / 2;
+        return $"{value[..halfLength]}...{value[^halfLength..]}";
+    }
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        var count = 0;
+        var index = 0;
+
+        while ((index = text.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+
+        return count;
+    }
+
+    private static void ApplySecretUpdate(
+        KubeCtl kubeCtl,
+        string secretName,
+        string @namespace,
+        List<Secret> secrets)
+    {
+        var filePath = PushCommand.CreateSecretsTempFile(secretName, @namespace, secrets);
+
+        try
+        {
+            kubeCtl.ApplyFile(filePath);
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+
+    private static bool PromptContinue(string question)
+    {
+        ConsoleKey response;
+        do
+        {
+            Console.Write($"{question} [y/N] ");
+            response = Console.ReadKey(false).Key;
+            if (response != ConsoleKey.Enter)
+            {
+                Console.WriteLine();
+            }
+        } while (response != ConsoleKey.Y && response != ConsoleKey.N && response != ConsoleKey.Enter);
+
+        return response == ConsoleKey.Y;
+    }
+
+    private record SecretUpdateInfo(
+        string Namespace,
+        string SecretName,
+        string KeyName,
+        string OldValue,
+        string NewValue,
+        int OccurrenceCount,
+        List<Secret> AllSecrets);
+}

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If you do not specify `--auto-create-missing-namespaces`, then it will not creat
 
 Search for secrets containing a specific value across all secrets in the cluster. This is useful for discovering which secrets contain a particular API key, password, or configuration value before rotating it.
 
-```
+```bash
 kubesec find <search-term> --context <kubectl-context-name>
 ```
 
@@ -187,23 +187,23 @@ There are three more options that you can add to the command:
 
 If you do not specify `--context`, then it will use whatever context is currently active in kubectl.
 
-#### Examples
+### Examples
 
 a) This command will search for "OpenAI" in all secrets in a cluster with the kubectl context name `production`:
 
-```
+```bash
 kubesec find "OpenAI" --context production
 ```
 
 b) This command will search for an API key in all secrets within the `likvido-api` namespace:
 
-```
+```bash
 kubesec find "sk-<your-api-key>" --namespace likvido-api --context production
 ```
 
 The output shows each matching secret with context lines around the match:
 
-```
+```text
 Finding: OpenAI
 =============================================
 
@@ -220,7 +220,7 @@ Finding: OpenAI
 
 Replace a specific value across all secrets in the cluster. This is useful for rotating API keys, passwords, or other credentials that are used by multiple services.
 
-```
+```bash
 kubesec update-value --old <old-value> --new <new-value> --context <kubectl-context-name>
 ```
 
@@ -241,29 +241,29 @@ Additional options:
 
 If you do not specify `--context`, then it will use whatever context is currently active in kubectl.
 
-#### Examples
+### Examples
 
 a) Preview what would be changed when rotating an API key (dry run):
 
-```
+```bash
 kubesec update-value --old "sk-oldkey123" --new "sk-newkey456" --context production --dry-run
 ```
 
 b) Rotate an API key across all secrets:
 
-```
+```bash
 kubesec update-value --old "sk-oldkey123" --new "sk-newkey456" --context production
 ```
 
 c) Rotate an API key only in a specific namespace:
 
-```
+```bash
 kubesec update-value --old "sk-oldkey123" --new "sk-newkey456" --namespace likvido-api --context production
 ```
 
 The output shows a preview of all changes and asks for confirmation:
 
-```
+```text
 =============================================
 Replace Values
 =============================================
@@ -300,7 +300,7 @@ Rollback: kubesec restore -c production kubesec-rollback-20260115-143022/
 
 If something goes wrong, you can rollback using the restore command with the backup folder that was created:
 
-```
+```bash
 kubesec restore kubesec-rollback-20260115-143022/ --context production --recursive
 ```
 


### PR DESCRIPTION
## Summary

Closes Likvido/Likvido.App#26094

Implement two new commands for secret rotation:
- **find**: Search for values across all secrets in the cluster with context lines
- **update-value**: Replace values across all matching secrets with automatic backup and rollback support

## Changes

- Created `FindCommand.cs` for searching secrets with context highlighting
- Created `UpdateValueCommand.cs` for bulk secret rotation with dry-run mode
- Refactored `BackupCommand` to expose reusable `CreateBackup` method
- Made `PushCommand.CreateSecretsTempFile` public for reuse
- Added `CancellationToken` support throughout all commands for graceful cancellation
- Modernized infrastructure classes to use C# 12 primary constructors
- Updated README with comprehensive documentation and examples

## Testing

- Build succeeds with no errors or warnings
- Both commands support namespace filtering (exact, includes, regex)
- Dry-run mode available for preview without making changes
- Automatic backup created before applying updates
- Cancellation tokens properly propagated through all operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `find` command to search for terms within Kubernetes secrets with highlighted matches and context.
  * Added `update-value` command to replace values across secrets with timestamped backups and rollback capabilities.

* **Documentation**
  * Updated documentation with examples and options for the new `find` and `update-value` commands.

* **Improvements**
  * Added cancellation support across backup, pull, and restore commands for better responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->